### PR TITLE
Add basic CI, K8s manifests, Skaffold, enable service account in go

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,29 @@
 # Retail-Banking-Microservices-Demo
 
+## Quickstart
+
+1. Install requirements
+   - skaffold ≥v1.0.1
+   - kubectl
+   - Docker
+2. Generate kubeconfig for your kubernetes cluster. The services will be deployed to this cluster
+   - For local development you can use k8s with Docker Desktop
+   - You can also configure kubeconfig for a remote cluster. With gcloud, `gcloud container clusters get-credentials [$CLUSTER_NAME] --project [$PROJECT_NAME] --[region/zone] [$REGION/ZONE]`
+3. Configure service account secret for the services to use.
+   - Run `kubectl create secret generic svc-key --from-file [$ABSOLUTE_PATH_TO_KEY]/service-acc.json` to make a k8s secret to store credentials
+4. Configure project id as a configmap for the services to use.
+   - Run `kubectl create configmap env-vars --from-literal=env.project-id=[$PROJECT_ID] -o yaml --dry-run | kubectl apply -f -` to make a k8s configmap with project id
+5. Build and run services by following any one of the steps below.
+   - Run `skaffold run` for running locally
+   - Run `skaffold run --default-repo=gcr.io/[$PROJECT_ID]` for getting images from remote registry
+   - RUN `skaffold run -p gcb --default-repo=gcr.io/[$PROJECT_ID]` for remotely building docker images
+   - Run `skaffold dev --default-repo=gcr.io/[$PROJECT_ID]` for constantly watching code changes locally and rebuilding locally
+   - Run `skaffold dev -p gcb --default-repo=gcr.io/[$PROJECT_ID]` for constantly watching code changes locally and rebuilding remotely
+
+6. Application should be available at service external IP or localhost
+   - Frontend: localhost/svc-external-ip:80
+   - ProfileService: localhost/svc-external-ip:8080
+
 ## frontend
 
 ## frontendservice

--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@
    - [Docker](https://docs.docker.com/v17.12/install/)
 2. Generate kubeconfig for your kubernetes cluster. The services will be deployed to this cluster
    - For local development you can use k8s with Docker Desktop
-   - You can also configure kubeconfig for a remote cluster. With gcloud, `gcloud container clusters get-credentials [$CLUSTER_NAME] --project [$PROJECT_NAME] --[region/zone] [$REGION/ZONE]`
+   - You can also configure kubeconfig for a remote cluster. 
+        - With gcloud, to create cluster `gcloud container clusters create [$CLUSTER_NAME] --project [$PROJECT_NAME] --[region/zone] [$REGION/ZONE]`
+
+        - To generate kubeconfig   `gcloud container clusters get-credentials [$CLUSTER_NAME] --project [$PROJECT_NAME] --[region/zone] [$REGION/ZONE]`
 3. Configure service account secret for the services to use.
    - Run `kubectl create secret generic svc-key --from-file [$ABSOLUTE_PATH_TO_KEY]/service-acc.json` to make a k8s secret to store credentials
 4. Configure project id as a configmap for the services to use.

--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@
 ## Quickstart
 
 1. Install requirements
-   - skaffold ≥v1.0.1
-   - kubectl
-   - Docker
+
+   - [skaffold](https://skaffold.dev/docs/install/)
+
+   - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+   - [Docker](https://docs.docker.com/v17.12/install/)
 2. Generate kubeconfig for your kubernetes cluster. The services will be deployed to this cluster
    - For local development you can use k8s with Docker Desktop
    - You can also configure kubeconfig for a remote cluster. With gcloud, `gcloud container clusters get-credentials [$CLUSTER_NAME] --project [$PROJECT_NAME] --[region/zone] [$REGION/ZONE]`

--- a/build/cloudbuild.yaml
+++ b/build/cloudbuild.yaml
@@ -1,0 +1,23 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+- id: 'Deploy application to cluster'
+  name: 'gcr.io/k8s-skaffold/skaffold:v1.0.1'
+  entrypoint: 'bash'
+  args:
+  - '-c'
+  - |
+    gcloud container clusters get-credentials --zone=$_ZONE $_CLUSTER;
+    skaffold run -f=skaffold.yaml --default-repo=gcr.io/$PROJECT_ID;

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,12 @@
+#build react
+FROM node:10-alpine as react-build
+WORKDIR .
+COPY package.json yarn.lock ./
+RUN yarn install
+COPY . ./
+RUN yarn build
+#copy artifacts for thin image
+FROM nginx:alpine
+COPY --from=react-build /build /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/k8s/deployment.yaml
+++ b/frontend/k8s/deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  selector:
+    matchLabels:
+      app: frontend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+        - name: frontend-container
+          image: frontend
+          ports:
+            - name: http
+              containerPort: 80

--- a/frontend/k8s/svc.yaml
+++ b/frontend/k8s/svc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend-svc
+spec:
+  selector:
+    app: frontend
+  ports:
+  - protocol: "TCP"
+    port: 80
+    targetPort: 80
+  type: LoadBalancer

--- a/profileservice/Dockerfile
+++ b/profileservice/Dockerfile
@@ -1,9 +1,10 @@
 #version number
 FROM golang:latest 
 WORKDIR /app
-ADD . /app
+#cache dependencies for faster builds
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
 RUN go build -o main . 
-COPY ./svc.json /app
-ENV GOOGLE_APPLICATION_CREDENTIALS /app/svc.json
 ENTRYPOINT ["/app/main"]
 EXPOSE 8080

--- a/profileservice/go.sum
+++ b/profileservice/go.sum
@@ -39,6 +39,7 @@ golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6 h1:bjcUS9ztw9kFmmIxJInhon/0Is3p+EHBKNgquIzo1OI=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=

--- a/profileservice/k8s/deployment.yaml
+++ b/profileservice/k8s/deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: go-app
+spec:
+  selector:
+    matchLabels:
+      app: go-app
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: go-app
+    spec:
+      containers:
+        - name: go-app-container
+          image: profileservice
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: "PROJECT_ID"
+              valueFrom:
+                configMapKeyRef:
+                  name: env-vars
+                  key: env.project-id
+            - name: "GOOGLE_APPLICATION_CREDENTIALS"
+              value: "/var/goog/secrets/service-acc.json"
+          volumeMounts:
+            - name: "service-account"
+              mountPath: "/var/goog/secrets"
+              readOnly: true
+      volumes:
+      - name: "service-account"
+        secret:
+          secretName: svc-key

--- a/profileservice/k8s/svc.yaml
+++ b/profileservice/k8s/svc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: go-app-svc
+spec:
+  selector:
+    app: go-app
+  ports:
+  - protocol: "TCP"
+    port: 8080
+    targetPort: 8080
+  type: LoadBalancer

--- a/profileservice/main.go
+++ b/profileservice/main.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"context"
-	"net/http"
 	"encoding/json"
+	"net/http"
 	"os"
+
 	//"io"
 	"log"
 	//"fmt"
@@ -13,6 +14,10 @@ import (
 	"github.com/gorilla/mux"
 	//"github.com/gorilla/handlers"
 	"strconv"
+
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/option"
+
 	//"google.golang.org/appengine"
 	//"google.golang.org/appengine/datastore"
 	"cloud.google.com/go/datastore"
@@ -20,12 +25,12 @@ import (
 
 // Kind in Datastore
 type User struct {
-	UserID int64 `json: "userid"`
-	Username string `json: "username"`
-	Address string `json: "address"`
-	Email string `json: "email"`
-	Password string `json: "password"`
-	PhoneNumber int64 `json: "phonenumber"`
+	UserID         int64   `json: "userid"`
+	Username       string  `json: "username"`
+	Address        string  `json: "address"`
+	Email          string  `json: "email"`
+	Password       string  `json: "password"`
+	PhoneNumber    int64   `json: "phonenumber"`
 	AccountBalance float64 `json: "accountbalance"`
 }
 
@@ -35,8 +40,12 @@ func main() {
 	ctx := context.Background()
 
 	var err error
+	creds, err := google.CredentialsFromJSON(ctx, []byte(os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")), datastore.ScopeDatastore)
+	if err != nil {
+		// TODO: handle error.
+	}
 	// TODO: get project ID from gae context
-	dsClient, err = datastore.NewClient(ctx, os.Getenv("PROJECT_ID"))
+	dsClient, err = datastore.NewClient(ctx, os.Getenv("PROJECT_ID"), option.WithCredentials(creds))
 	//dsClient, err = datastore.NewClient(ctx, appengine.AppID(ctx))
 
 	if err != nil {
@@ -75,7 +84,7 @@ func createHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func listHandler (w http.ResponseWriter, r *http.Request) {
+func listHandler(w http.ResponseWriter, r *http.Request) {
 	//ctx := appengine.NewContext(r)
 	ctx := context.Background()
 	user := make([]*User, 0)
@@ -86,7 +95,7 @@ func listHandler (w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	res, _ := json.Marshal(&user)
-	w.Write(res)	
+	w.Write(res)
 }
 
 func readHandler(w http.ResponseWriter, r *http.Request) {
@@ -129,7 +138,7 @@ func deleteHandler(w http.ResponseWriter, r *http.Request) {
 	// todo: fix error message
 	if err := dsClient.DeleteMulti(ctx, keys); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return		
+		return
 	}
 }
 
@@ -165,26 +174,14 @@ func updateHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-
 // 	// Respond to App Engine and Compute Engine health checks.
 // 	// Indicate the server is healthy.
 // 	// r.Methods("GET").Path("/_ah/health").HandlerFunc(
 // 	// 	func(w http.ResponseWriter, r *http.Request) {
 // 	// 		w.Write([]byte("ok"))
 // 	// 	})
-		
+
 // 	// Delegate all of the HTTP routing and serving to the gorilla/mux router.
 // 	// Log all requests using the standard Apache format.
 // 	// http.Handle("/", handlers.CombinedLoggingHandler(os.Stderr, r))
 // }
-
-
-
-
-
-
-
-
-
-
-

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,0 +1,44 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: skaffold/v1
+kind: Config
+build:
+  artifacts:
+    - image: frontend
+      context: ./frontend/
+    - image: profileservice
+      context: ./profileservice/
+deploy:
+  kubectl:
+    manifests:
+      - ./frontend/k8s/*
+      - ./profileservice/k8s/*
+portForward:
+  - resourceType: deployment
+    resourceName: frontend
+    port: 80
+    localPort: 80
+  - resourceType: deployment
+    resourceName: profileservice
+    port: 8080
+    localPort: 8080
+profiles:
+#for remote builds
+- name: gcb
+  build:
+    googleCloudBuild:
+      diskSizeGb: 10
+      machineType: N1_HIGHCPU_8
+      timeout: 1200s


### PR DESCRIPTION
Fixes #11, #12, #13

- Added Cloudbuild
- Added Skaffold
- Added multi stage Dockerfile for Frontend
- Enabled cached dependencies in Dockerfile for Go
- Enables use of service account file in Go
- Added k8s manifests with secrets and env via ConfigMaps 